### PR TITLE
Update to 4.18 kernel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.o
+*.order
+*.o.cmd
+*/.tmp_versions/
+*.ko
+*.ko.cmd
+*.mod.c
+Module.symvers

--- a/Readme.md
+++ b/Readme.md
@@ -4,4 +4,4 @@ Published by O'Reilly and Associates, 2005
 
 This source was initially downloaded from the author's ftp
 site: ftp://ar.linux.it/pub/ldd3/ and has been modified to
-work on more recent kernels (v3.3.0).
+work on more recent kernels (v4.18.0).


### PR DESCRIPTION
See refactor in 3.9.1 [here](torvalds/linux@496ad9a) for file_inode.  
The current implementation should continue to support older kernels, 
however this has not been tested.  So far I've only updated misc-modules, the root directory isn't building on 4.18 yet.